### PR TITLE
remove codes for coverage calculation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 r-dplyr
 r-readr
+seqtk

--- a/sbx_contigs.rules
+++ b/sbx_contigs.rules
@@ -139,4 +139,4 @@ rule summarize_coverage:
     output:
         str(ASSEMBLY_FP/'sbx_contigs'/'reports'/'coverage.csv')
     shell:
-        "(head -n 1 {input[0]}; tail -q -n +2 {input}) > {output}"
+        "(


### PR DESCRIPTION
The rules for mapping reads to contigs and calculating the per base coverage have been moved to coverage.rules of sunbeam. Therefore clean up the codes here.